### PR TITLE
Fix for dev dplyr

### DIFF
--- a/R/formatters.R
+++ b/R/formatters.R
@@ -108,7 +108,7 @@ format_currency <- function(tbl, ..., symbol = "yen", digits = 0){
 is_percentage <- function(x){
 
   suppressWarnings({
-    all(dplyr::between(x, -1, 1), na.rm = T) & is.double(x) & !rlang::is_integerish(x)
+    is.double(x) && all(dplyr::between(x, -1, 1), na.rm = T) & !rlang::is_integerish(x)
   })
 
 }


### PR DESCRIPTION
Check that `x` is a double first, so we don't use between() on (e.g.) a factor.